### PR TITLE
Add Calculator demo

### DIFF
--- a/calc/Calculator/Makefile
+++ b/calc/Calculator/Makefile
@@ -1,0 +1,18 @@
+CC = gcc
+DEPS = add.c subtract.c multiply.c devide.c
+OBJS := ${DEPS:c=o}
+
+all: calc
+
+calc: libcalc.so
+	${CC} main.c -o calc -L. -lcalc -ljson-c
+
+libcalc.so: ${OBJS}
+	${CC} -shared -o libcalc.so ${OBJS}
+
+# When building with more than one job this will be issued more than once. This is done on purpose!
+${OBJS}: ${DEPS}
+	${CC} -c $^
+
+clean:
+	rm -rf *.o libcalc.so calc

--- a/calc/Calculator/add.c
+++ b/calc/Calculator/add.c
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2018 Math Codder <mc@endocode.com>
+ * 
+ * SPDX-License-Identifier: GPL-3.0
+ */
+
+int Add(int a, int b) {
+    return a + b;
+}

--- a/calc/Calculator/calc.h
+++ b/calc/Calculator/calc.h
@@ -1,0 +1,9 @@
+#ifndef _CALC_
+#define _CALC_
+
+int Add(int a, int b);
+int Subtract(int a, int b);
+int Multiply(int a, int b);
+int Devide(int a, int b);
+
+#endif

--- a/calc/Calculator/devide.c
+++ b/calc/Calculator/devide.c
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2018 Math Codder <mc@endocode.com>
+ * 
+ * SPDX-License-Identifier: GPL-3.0
+ */
+
+int Devide(int a, int b) {
+    if (b == 0) {
+        return 0;
+    }
+    return a / b;
+}

--- a/calc/Calculator/main.c
+++ b/calc/Calculator/main.c
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2018 Math Codder <mc@endocode.com>
+ * 
+ * SPDX-License-Identifier: GPL-3.0
+ */
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <json-c/json.h>
+#include "calc.h"
+
+void usage(char * prog);
+void printResult(const char * op, int a, int b, int res);
+
+int main(int argc, char ** argv) {
+    if (argc != 4) {
+        usage(argv[0]);
+        return 1;
+    }
+
+    char sw = argv[1][0];
+    int res, a, b;
+
+    a = atoi(argv[2]);
+    b = atoi(argv[3]);
+
+    switch (sw) {
+    case 'a':
+        res = Add(a, b);
+        break;
+    case 's':
+        res = Subtract(a, b);
+        break;
+    case 'm':
+        res = Multiply(a, b);
+        break;
+    case 'd':
+        res = Devide(a, b);
+        break;
+    default:
+        usage(argv[0]);
+        return 1;
+    }
+
+    printResult(argv[1], a, b, res);
+}
+
+void usage(char * prog) {
+    printf("%s <op> <int> <int>\n", prog);
+    printf("Op can be one of add,sub,mul,div\n\n");
+}
+
+void printResult(const char * op, int a, int b, int res) {
+    struct json_object *obj = json_object_new_object();
+
+    json_object_object_add(obj, "op", json_object_new_string(op));
+    json_object_object_add(obj, "a", json_object_new_int(a));
+    json_object_object_add(obj, "b", json_object_new_int(b));
+    json_object_object_add(obj, "res", json_object_new_int(res));
+
+    printf("You calld for op %s with numbers %d and %d and result is: %d\n", op, a, b, res);
+    printf("Here's a json for you\n");
+    printf("%s\n", json_object_to_json_string(obj));
+}

--- a/calc/Calculator/multiply.c
+++ b/calc/Calculator/multiply.c
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2018 Math Codder <mc@endocode.com>
+ * 
+ * SPDX-License-Identifier: GPL-3.0
+ */
+
+int Multiply(int a, int b) {
+    return a * b;
+}

--- a/calc/Calculator/subtract.c
+++ b/calc/Calculator/subtract.c
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2018 Math Codder <mc@endocode.com>
+ * 
+ * SPDX-License-Identifier: GPL-3.0
+ */
+
+int Subtract(int a, int b) {
+    return a - b;
+}

--- a/calc/build.sh
+++ b/calc/build.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+set -e
+
+JSONC_BRANCH="master"
+
+function run_qmstr_prod() {
+    docker run --rm -d -p 50051:50051 -v $(pwd):/buildroot qmstr/master
+}
+
+function run_qmstr_dev() {
+    if [ -z "$QMSTR_SRC" ]; then
+        echo "Please set QMSTR_SRC to point to your qmstr source directory."
+        exit 2
+    fi
+    docker run --rm -d -p 50051:50051 -p 8081:8081 -p 8080:8080 -v "${QMSTR_SRC}":/go/src/github.com/QMSTR/qmstr -v $(pwd):/buildroot qmstr/dev
+
+}
+
+if [ -z "$QMSTR_HOME" ]; then
+    echo "Please set QMSTR_HOME. See github.com/QMSTR/qmstr-demo."
+    exit 1
+fi
+
+export PATH=$QMSTR_HOME/bin:$PATH
+
+if [ -z "$QMSTR_DEBUG" ]; then
+    run_qmstr_prod
+else
+    run_qmstr_dev
+fi
+
+git clone -b ${JSONC_BRANCH} https://github.com/json-c/json-c.git || (cd json-c; git fetch; git reset --hard origin/${JSONC_BRANCH})
+cd json-c
+git clean -fxd
+
+qmstr-cli wait
+
+sh autogen.sh
+./configure
+
+make -j4
+LIBRARY_PATH=$(pwd)/.libs
+
+cd ..
+export C_INCLUDE_PATH="$(pwd)"
+cd Calculator
+make clean
+
+export LIBRARY_PATH
+make -j4
+
+echo "Build finished. Don't forget to quit the qmstr-master server."


### PR DESCRIPTION
This builds a demo application that builds libjson-c from its git
repository, a libcalc.so from some c files and links everything together
into an executable.

This tests in addition to compile and linking with gcc library lookup
via -L and LIBRARY_PATH environment variable.

It also test that multiple build jobs and repeated builds of the same
files are handled properly by the database. Therefore the "bug" in the
demo's Makefile that causes the four sourcefiles to be build 4 times is
done on purpose and should not be "fixed".

To run the build script a QMSTR_HOME environment variable must be set to
a directory that contains a bin directory containing at least a gcc
symlinked to qmstr-wrapper.