### PR TITLE
Combine RUN apt-get update with install

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -1,7 +1,6 @@
 FROM qmstr/runtime as demobase
 
-RUN apt-get update
-RUN apt-get install -y ccache
+RUN apt-get update && apt-get install -y ccache
 
 # install runtime deps
 COPY --from=qmstr/master_build /usr/local/bin/qmstr /usr/local/bin/qmstr
@@ -33,8 +32,7 @@ RUN rm -fr /tmp/qmstr
 
 FROM demobase as javademobase
 
-RUN apt-get update
-RUN apt-get install -y openjdk-8-jdk openjfx
+RUN apt-get update && apt-get install -y openjdk-8-jdk openjfx
 
 RUN mkdir -p /maven/conf
 ENV M2_HOME /maven

--- a/demos/calc/Dockerfile
+++ b/demos/calc/Dockerfile
@@ -1,7 +1,6 @@
 FROM qmstr/demo
 # install runtime deps
-RUN apt-get update
-RUN apt-get install -y libjson-c-dev
+RUN apt-get update && apt-get install -y libjson-c-dev
 
 VOLUME /buildroot
 

--- a/demos/curl/Dockerfile
+++ b/demos/curl/Dockerfile
@@ -1,7 +1,6 @@
 FROM qmstr/demo
 # install runtime deps
-RUN apt-get update
-RUN apt-get install -y cmake libtool pkgconf libssl-dev
+RUN apt-get update && apt-get install -y cmake libtool pkgconf libssl-dev
 
 VOLUME /buildroot
 

--- a/demos/jsonc/Dockerfile
+++ b/demos/jsonc/Dockerfile
@@ -1,7 +1,6 @@
 FROM qmstr/demo
 # install runtime deps
-RUN apt-get update
-RUN apt-get install -y libtool pkgconf
+RUN apt-get update && apt-get install -y libtool pkgconf
 
 VOLUME /buildroot
 

--- a/demos/openssl/Dockerfile
+++ b/demos/openssl/Dockerfile
@@ -1,7 +1,6 @@
 FROM qmstr/demo
 # install runtime deps
-RUN apt-get update
-RUN apt-get install -y libtool pkgconf perl libssl-dev
+RUN apt-get update && apt-get install -y libtool pkgconf perl libssl-dev
 
 VOLUME /buildroot
 


### PR DESCRIPTION
Use RUN apt-get update with apt-get install in the same RUN  to avoid cashing issues
and subsequently avoid apt-get install to fail.