### PR TITLE
Force to override snapshot if exists

### DIFF
--- a/demos/calc/build.sh
+++ b/demos/calc/build.sh
@@ -24,11 +24,11 @@ popd
 qmstr --container qmstr/calcdemo -- make -j4
 
 echo "[INFO] Build finished. Creating snapshot and triggering analysis."
-qmstrctl snapshot -O postbuild-snapshot.tar
+qmstrctl snapshot -O postbuild-snapshot.tar -f
 qmstrctl analyze --verbose
 
 echo "[INFO] Analysis finished. Creating snapshot and triggering reporting."
-qmstrctl snapshot -O postanalysis-snapshot.tar
+qmstrctl snapshot -O postanalysis-snapshot.tar -f
 qmstrctl report --verbose
 
 qmstrctl quit

--- a/demos/curl/build.sh
+++ b/demos/curl/build.sh
@@ -30,11 +30,11 @@ qmstr --verbose --container qmstr/curldemo -- cmake ..
 qmstr --verbose --container qmstr/curldemo -- make
 
 echo "[INFO] Build finished. Creating snapshot and triggering analysis."
-qmstrctl snapshot -O postbuild-snapshot.tar 
+qmstrctl snapshot -O postbuild-snapshot.tar -f
 qmstrctl analyze --verbose
 
 echo "[INFO] Analysis finished. Creating snapshot and triggering reporting."
-qmstrctl snapshot -O postanalysis-snapshot.tar 
+qmstrctl snapshot -O postanalysis-snapshot.tar -f
 qmstrctl report --verbose
 
 qmstrctl quit

--- a/demos/java-jabref/build.sh
+++ b/demos/java-jabref/build.sh
@@ -28,11 +28,11 @@ echo "[INFO] Start gradle build"
 qmstr --container qmstr/java-jabrefdemo ./gradlew qmstr
 
 echo "[INFO] Build finished. Creating snapshot and triggering analysis."
-qmstrctl snapshot -O postbuild-snapshot.tar 
+qmstrctl snapshot -O postbuild-snapshot.tar -f
 qmstrctl analyze --verbose
 
 echo "[INFO] Analysis finished. Creating snapshot and triggering reporting."
-qmstrctl snapshot -O postanalysis-snapshot.tar 
+qmstrctl snapshot -O postanalysis-snapshot.tar -f
 qmstrctl report --verbose
 
 qmstrctl quit

--- a/demos/jsonc/build.sh
+++ b/demos/jsonc/build.sh
@@ -24,11 +24,11 @@ qmstr --container qmstr/jsoncdemo -- ./configure
 qmstr --container qmstr/jsoncdemo -- make
 
 echo "[INFO] Build finished. Creating snapshot and triggering analysis."
-qmstrctl snapshot -O postbuild-snapshot.tar 
+qmstrctl snapshot -O postbuild-snapshot.tar -f
 qmstrctl analyze --verbose
 
 echo "[INFO] Analysis finished. Creating snapshot and triggering reporting."
-qmstrctl snapshot -O postanalysis-snapshot.tar 
+qmstrctl snapshot -O postanalysis-snapshot.tar -f
 qmstrctl report --verbose
 
 qmstrctl quit

--- a/demos/openssl/build.sh
+++ b/demos/openssl/build.sh
@@ -27,11 +27,11 @@ qmstr --verbose --container qmstr/openssldemo -- ./config
 qmstr --verbose --container qmstr/openssldemo -- make
 
 echo "[INFO] Build finished. Creating snapshot and triggering analysis."
-qmstrctl snapshot -O postbuild-snapshot.tar 
+qmstrctl snapshot -O postbuild-snapshot.tar -f
 qmstrctl analyze --verbose
 
 echo "[INFO] Analysis finished. Creating snapshot and triggering reporting."
-qmstrctl snapshot -O postanalysis-snapshot.tar 
+qmstrctl snapshot -O postanalysis-snapshot.tar -f
 qmstrctl report --verbose
 
 qmstrctl quit


### PR DESCRIPTION
Use the -f flag to force to override the snapshot if already exists
in this directory.