### PR TITLE
Change reporter url

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ demos/curl/curl
 demos/jsonc/jsonc
 demos/openssl/openssl
 demos/java-jabref/jabref
+demos/icecream/icecream
 **/qmstr
 **/reports
 **/ana.yaml

--- a/demos/calc/qmstr.yaml
+++ b/demos/calc/qmstr.yaml
@@ -49,4 +49,4 @@ package:
       name: "HTML Reporter"
       config:
         siteprovider: "Endocode"
-        baseurl: "http://qmstr.org/packages/"
+        baseurl: "http://localhost:8080/"

--- a/demos/curl/qmstr.yaml
+++ b/demos/curl/qmstr.yaml
@@ -41,4 +41,4 @@ package:
       name: "HTML Reporter"
       config:
         siteprovider: "Endocode"
-        baseurl: "http://qmstr.org/packages/"
+        baseurl: "http://localhost:8080/"

--- a/demos/java-jabref/qmstr.yaml
+++ b/demos/java-jabref/qmstr.yaml
@@ -41,5 +41,5 @@ package:
       name: "HTML Reporter"
       config:
         siteprovider: "Endocode"
-        baseurl: "http://qmstr.org/packages/"
+        baseurl: "http://localhost:8080/"
         outputdir: /buildroot/

--- a/demos/jsonc/qmstr.yaml
+++ b/demos/jsonc/qmstr.yaml
@@ -50,5 +50,5 @@ package:
       name: "HTML Reporter"
       config:
         siteprovider: "Endocode"
-        baseurl: "http://qmstr.org/packages/"
+        baseurl: "http://localhost:8080/"
         outputdir: /buildroot/

--- a/demos/openssl/qmstr.yaml
+++ b/demos/openssl/qmstr.yaml
@@ -41,5 +41,5 @@ package:
       name: "HTML Reporter"
       config:
         siteprovider: "Endocode"
-        baseurl: "http://qmstr.org/packages/"
+        baseurl: "http://localhost:8080/"
         outputdir: /buildroot/


### PR DESCRIPTION
Currently the documentation is not published in the qmstr.org website and
we can observe the documentation via localhost.