### PR TITLE
Remove pkg and git analyzers

### DIFF
--- a/demos/calc/SPDX.tag
+++ b/demos/calc/SPDX.tag
@@ -14,7 +14,7 @@ ReviewDate: 2018-05-17T00:00:00Z
 ReviewComment: <text>LGTM</text>
 
 ## Package Information
-PackageName: The Calculator
+PackageName: calc
 PackageVersion: Version 0.1
 PackageDownloadLocation: http://www.example.org/thecalc
 PackageSummary: <text>A simple calculation utility</text>

--- a/demos/calc/build.sh
+++ b/demos/calc/build.sh
@@ -17,8 +17,7 @@ echo "Waiting for qmstr-master server"
 eval $(qmstrctl start --wait)
 echo "master server up and running"
 
-qmstrctl create package:calc --version 00000
-
+qmstrctl create package:calc
 pushd Calculator
 make clean
 popd

--- a/demos/calc/build.sh
+++ b/demos/calc/build.sh
@@ -17,13 +17,15 @@ echo "Waiting for qmstr-master server"
 eval $(qmstrctl start --wait)
 echo "master server up and running"
 
-qmstrctl create package:calc
+qmstrctl create package:calc --version 00000
 
 pushd Calculator
 make clean
 popd
 
 qmstr --container qmstr/calcdemo -- make -j4
+
+qmstrctl connect package:calc file:Calculator/libcalc.a file:Calculator/calcs file:Calculator/libcalc.so file:Calculator/calc
 
 echo "[INFO] Build finished. Creating snapshot and triggering analysis."
 qmstrctl snapshot -O postbuild-snapshot.tar -f

--- a/demos/calc/qmstr.yaml
+++ b/demos/calc/qmstr.yaml
@@ -9,11 +9,6 @@ project:
     dbaddress: "localhost:9080"
     dbworkers: 4
   analysis:
-    - analyzer: pkg-analyzer
-      name: "Package Analyzer"
-      config:
-        targetdir: "/buildroot/Calculator/"
-        targets: "calc;libcalc.so;calcs;libcalc.a"
     - analyzer: spdx-identifier-analyzer
       name: "Simple SPDX Analyzer"
       trustlevel: 300
@@ -25,7 +20,7 @@ project:
       config:
         workdir: "/buildroot"
         resultfile: "/buildroot/scancode.json"
-        # cached: "true"
+        #cached: "true"
     - analyzer: test-analyzer
       name: "Simple CI Test Analyzer"
       config:
@@ -44,6 +39,6 @@ project:
     - reporter: qmstr-reporter-html
       name: "HTML Reporter"
       config:
-        # generatehtml: "no"
+        #generatehtml: "no"
         siteprovider: "Endocode"
         baseurl: "http://qmstr.org/packages/"

--- a/demos/curl/build.sh
+++ b/demos/curl/build.sh
@@ -25,11 +25,13 @@ echo "Waiting for qmstr-master server"
 eval $(qmstrctl start --wait --verbose)
 echo "master server up and running"
 
-qmstrctl create package:curl
+qmstrctl create package:curl --version $(cd curl && git describe --tags --dirty --long)
 
 echo "[INFO] Start curl build"
 qmstr --verbose --container qmstr/curldemo -- cmake ..
 qmstr --verbose --container qmstr/curldemo -- make
+
+qmstrctl connect package:curl file:curl/build/src/curl file:curl/build/lib/libcurl.so
 
 echo "[INFO] Build finished. Creating snapshot and triggering analysis."
 qmstrctl snapshot -O postbuild-snapshot.tar -f

--- a/demos/curl/qmstr.yaml
+++ b/demos/curl/qmstr.yaml
@@ -9,15 +9,6 @@ project:
     dbaddress: "localhost:9080"
     dbworkers: 4
   analysis:
-    - analyzer: pkg-analyzer
-      name: "Package Analyzer"
-      config:
-        targetdir: "/buildroot/curl/build/"
-        targets: "src/curl;lib/libcurl.so"
-    - analyzer: git-analyzer
-      name: "Git Analyzer"
-      config:
-        workdir: "/buildroot/curl"
     - analyzer: spdx-identifier-analyzer
       name: "Simple SPDX Analyzer"
       config:
@@ -27,7 +18,7 @@ project:
       config:
         workdir: "/buildroot"
         resultfile: "/buildroot/scancode.json"
-      #  # cached: "true"
+        #cached: "true"
     - analyzer: test-analyzer
       name: "Simple CI Test Analyzer"
       config:
@@ -40,6 +31,6 @@ project:
     - reporter: qmstr-reporter-html
       name: "HTML Reporter"
       config:
-        # generatehtml: "no"
+        #generatehtml: "no"
         siteprovider: "Endocode"
         baseurl: "http://qmstr.org/packages/"

--- a/demos/icecream/Dockerfile
+++ b/demos/icecream/Dockerfile
@@ -1,6 +1,6 @@
 FROM qmstr/demo
 
-RUN apt-get update && apt-get install -y libtool libcap-ng-dev liblzo2-dev
+RUN apt-get update && apt-get install -y libtool libcap-ng-dev liblzo2-dev libarchive-dev
 
 VOLUME /buildroot
 

--- a/demos/icecream/build.sh
+++ b/demos/icecream/build.sh
@@ -24,12 +24,14 @@ echo "Waiting for qmstr-master server"
 eval $(qmstrctl start --wait --verbose)
 echo "master server up and running"
 
-qmstrctl create package:icecream
+qmstrctl create package:icecream --version $(cd icecream && git describe --tags --dirty --long)
 
 echo "[INFO] Start icecream build"
 qmstr --verbose --container qmstr/icecreamdemo -- ./autogen.sh
 qmstr --verbose --container qmstr/icecreamdemo -- ./configure --prefix=/opt/icecream
 qmstr --verbose --container qmstr/icecreamdemo -- make
+
+qmstrctl connect package:icecream file:icecream/client/icecc file:icecream/daemon/iceccd
 
 echo "[INFO] Build finished. Creating snapshot and triggering analysis."
 qmstrctl snapshot -O postbuild-snapshot.tar -f

--- a/demos/icecream/qmstr.yaml
+++ b/demos/icecream/qmstr.yaml
@@ -9,15 +9,6 @@ project:
     dbaddress: "localhost:9080"
     dbworkers: 4
   analysis:
-    - analyzer: pkg-analyzer
-      name: "Package Analyzer"
-      config:
-        targetdir: "/buildroot/icecream/"
-        targets: "client/icecc;daemon/iceccd"
-    - analyzer: git-analyzer
-      name: "Git Analyzer"
-      config:
-        workdir: "buildroot/icecream"
     - analyzer: spdx-identifier-analyzer
       name: "Simple SPDX Analyzer"
       config:
@@ -27,7 +18,7 @@ project:
       config:
         workdir: "/buildroot"
         resultfile: "/buildroot/scancode.json"
-      #cached: "true"
+        #cached: "true"
     - analyzer: test-analyzer
       name: "Simple CI Test Analyzer"
       config:
@@ -40,6 +31,6 @@ project:
     - reporter: qmstr-reporter-html
       name: "HTML Reporter"
       config:
-        # generatehtml: "no"
+        #generatehtml: "no"
         siteprovider: "Endocode"
         baseurl: "http://localhost:8080/"

--- a/demos/java-jabref/build.sh
+++ b/demos/java-jabref/build.sh
@@ -24,10 +24,12 @@ popd
 echo "Waiting for qmstr-master server"
 eval $(qmstrctl start --wait --verbose)
 
-qmstrctl create package:jabref
+qmstrctl create package:jabref --version $(cd jabref && git describe --tags --dirty --long)
 
 echo "[INFO] Start gradle build"
 qmstr --container qmstr/java-jabrefdemo ./gradlew qmstr
+
+qmstrctl connect package:jabref file:$(find jabref -name "JabRef-?.?-dev.jar") 
 
 echo "[INFO] Build finished. Creating snapshot and triggering analysis."
 qmstrctl snapshot -O postbuild-snapshot.tar -f

--- a/demos/java-jabref/qmstr.yaml
+++ b/demos/java-jabref/qmstr.yaml
@@ -9,15 +9,6 @@ project:
     dbaddress: "localhost:9080"
     dbworkers: 4
   analysis:
-    - analyzer: pkg-analyzer
-      name: "Package Analyzer"
-      config:
-        targetdir: "/buildroot/jabref/"
-        targets: "build/libs/JabRef-.+-dev.jar"
-    - analyzer: git-analyzer
-      name: "Git Analyzer"
-      config:
-        workdir: "/buildroot/jabref"
     - analyzer: spdx-identifier-analyzer
       name: "Simple SPDX Analyzer"
       config:

--- a/demos/jsonc/build.sh
+++ b/demos/jsonc/build.sh
@@ -19,7 +19,7 @@ echo "Waiting for qmstr-master server"
 eval $(qmstrctl start --wait)
 echo "master server up and running"
 
-qmstrctl create project:jsonc --version $(cd jsonc && git describe --always)
+qmstrctl create package:jsonc --version $(cd jsonc && git describe --always)
 
 qmstr --container qmstr/jsoncdemo -- sh autogen.sh
 qmstr --container qmstr/jsoncdemo -- ./configure

--- a/demos/jsonc/build.sh
+++ b/demos/jsonc/build.sh
@@ -19,11 +19,13 @@ echo "Waiting for qmstr-master server"
 eval $(qmstrctl start --wait)
 echo "master server up and running"
 
-qmstrctl create project:jsonc
+qmstrctl create project:jsonc --version $(cd jsonc && git describe --always)
 
 qmstr --container qmstr/jsoncdemo -- sh autogen.sh
 qmstr --container qmstr/jsoncdemo -- ./configure
 qmstr --container qmstr/jsoncdemo -- make -j4
+
+qmstrctl connect package:jsonc file:$(find jsonc -name "libjson-c.so.?.*")
 
 echo "[INFO] Build finished. Creating snapshot and triggering analysis."
 qmstrctl snapshot -O postbuild-snapshot.tar -f

--- a/demos/jsonc/qmstr.yaml
+++ b/demos/jsonc/qmstr.yaml
@@ -10,11 +10,6 @@ project:
     dbworkers: 4
 
   analysis:
-    - analyzer: pkg-analyzer
-      name: "Package Analyzer"
-      config:
-        targetdir: "/buildroot/jsonc/.libs"
-        targets: "libjson-c\\.(?:so)|(?:dylib)\\.\\d\\.\\d.\\d"
     - analyzer: spdx-identifier-analyzer
       name: "Simple SPDX Analyzer"
       trustlevel: 300
@@ -26,11 +21,7 @@ project:
       config:
         workdir: "/buildroot"
         resultfile: "/buildroot/scancode.json"
-        # cached: "true"
-    - analyzer: git-analyzer
-      name: "Git Analyzer"
-      config:
-        workdir: "/buildroot/jsonc"
+        #cached: "true"
     - analyzer: test-analyzer
       name: "Simple CI Test Analyzer"
       config:
@@ -49,7 +40,7 @@ project:
     - reporter: qmstr-reporter-html
       name: "HTML Reporter"
       config:
-        # generatehtml: "no"
+        #generatehtml: "no"
         siteprovider: "Endocode"
         baseurl: "http://qmstr.org/packages/"
         outputdir: /buildroot/

--- a/demos/openssl/build.sh
+++ b/demos/openssl/build.sh
@@ -23,10 +23,12 @@ echo "Waiting for qmstr-master server"
 eval $(qmstrctl start --verbose --wait)
 echo "master server up and running"
 
-qmstrctl create package:openssl
+qmstrctl create package:openssl --version $(cd openssl && git describe --tags --dirty --long)
 
 qmstr --verbose --container qmstr/openssldemo -- ./config
 qmstr --verbose --container qmstr/openssldemo -- make
+
+qmstrctl connect package:openssl file:openssl/apps/openssl
 
 echo "[INFO] Build finished. Creating snapshot and triggering analysis."
 qmstrctl snapshot -O postbuild-snapshot.tar -f

--- a/demos/openssl/qmstr.yaml
+++ b/demos/openssl/qmstr.yaml
@@ -9,11 +9,6 @@ project:
     dbaddress: "localhost:9080"
     dbworkers: 4
   analysis:
-    - analyzer: pkg-analyzer
-      name: "Package Analyzer"
-      config:
-        targetdir: "/buildroot/openssl/"
-        targets: "apps/openssl"
     - analyzer: spdx-identifier-analyzer
       name: "Simple SPDX Analyzer"
       config:
@@ -23,15 +18,11 @@ project:
       config:
         workdir: "/buildroot"
         resultfile: "/buildroot/scancode.json"
-      #  # cached: "true"
+        #cached: "true"
     - analyzer: test-analyzer
       name: "Simple CI Test Analyzer"
       config:
         workdir: "/buildroot"
-    - analyzer: git-analyzer
-      name: "Git Analyzer"
-      config:
-        workdir: "/buildroot/openssl"
   reporting:
     - reporter: test-reporter
       name: "Test Reporter"
@@ -40,7 +31,7 @@ project:
     - reporter: qmstr-reporter-html
       name: "HTML Reporter"
       config:
-        # generatehtml: "no"
+        #generatehtml: "no"
         siteprovider: "Endocode"
         baseurl: "http://qmstr.org/packages/"
         outputdir: /buildroot/


### PR DESCRIPTION
Remove pkg and git analyzers from the yaml configuration files and
add the functionality in the build scripts.
Also add the option to skip the generation of the html pages in qmstr-reporter-html
in comment.