### PR TITLE
Create dummy project

### DIFF
--- a/demos/dummy/qmstr.yaml
+++ b/demos/dummy/qmstr.yaml
@@ -1,0 +1,17 @@
+project:
+  name: "Dummy project"
+  metadata:
+    Vendor: "Endocode"
+    OcFossLiaison: "Mirko Boehm"
+    OcComplianceContact: "foss@endocode.com"
+  server:
+    rpcaddress: ":50051"
+    dbaddress: "localhost:9080"
+    dbworkers: 4
+  analysis:
+  reporting:
+    - reporter: qmstr-reporter-html
+      name: "HTML Reporter"
+      config:
+        siteprovider: "Endocode"
+        baseurl: "http://qmstr.org/packages/"


### PR DESCRIPTION
Dummy project is introduced to start a master process and only
run the html reporter. This is useful in the CI process to generate
a hugo web site with the data cached in the specified cache dir.