### PR TITLE
Connect missing dependencies

### DIFF
--- a/demos/debian-curl/targets.sh
+++ b/demos/debian-curl/targets.sh
@@ -15,12 +15,12 @@ function getOldestHash() {
 
 # create curl targets
 CURL_BDIR=curl/debian/curl/usr/
-qmstrctl create file:${CURL_BDIR}share/doc/curl/NEWS.Debian.gz
-qmstrctl create file:${CURL_BDIR}share/doc/curl/changelog.gz
-qmstrctl create file:${CURL_BDIR}share/doc/curl/copyright
-qmstrctl create file:${CURL_BDIR}share/doc/curl/changelog.Debian.gz
-qmstrctl create file:${CURL_BDIR}share/man/man1/curl.1.gz
-qmstrctl create file:${CURL_BDIR}share/zsh/vendor-completions/_curl
+qmstrctl create file:${CURL_BDIR}share/doc/curl/NEWS.Debian.gz --name NEWS.Debian.gz
+qmstrctl create file:${CURL_BDIR}share/doc/curl/changelog.gz --name changelog.gz
+qmstrctl create file:${CURL_BDIR}share/doc/curl/copyright --name copyright
+qmstrctl create file:${CURL_BDIR}share/doc/curl/changelog.Debian.gz --name changelog.Debian.gz
+qmstrctl create file:${CURL_BDIR}share/man/man1/curl.1.gz --name curl.1.gz
+qmstrctl create file:${CURL_BDIR}share/zsh/vendor-completions/_curl --name _curl
 
 # connect targets to curl package
 qmstrctl connect package:curl_7.64.0-3_amd64.deb \
@@ -38,10 +38,10 @@ qmstrctl connect file:hash:$(getOldestHash ${CURL_BDIR}bin/curl) \
 
 # create libcurl4 targets
 LIBCURL_BDIR=curl/debian/libcurl4/usr/
-qmstrctl create file:${LIBCURL_BDIR}share/doc/libcurl4/NEWS.Debian.gz
-qmstrctl create file:${LIBCURL_BDIR}share/doc/libcurl4/changelog.Debian.gz
-qmstrctl create file:${LIBCURL_BDIR}share/doc/libcurl4/changelog.gz
-qmstrctl create file:${LIBCURL_BDIR}share/doc/libcurl4/copyright
+qmstrctl create file:${LIBCURL_BDIR}share/doc/libcurl4/NEWS.Debian.gz --name NEWS.Debian.gz
+qmstrctl create file:${LIBCURL_BDIR}share/doc/libcurl4/changelog.Debian.gz --name changelog.Debian.gz
+qmstrctl create file:${LIBCURL_BDIR}share/doc/libcurl4/changelog.gz --name changelog.gz
+qmstrctl create file:${LIBCURL_BDIR}share/doc/libcurl4/copyright --name copyright
 
 # connect targets to libcurl4 package
 qmstrctl connect package:libcurl4_7.64.0-3_amd64.deb \
@@ -57,13 +57,13 @@ qmstrctl connect file:hash:$(getOldestHash ${LIBCURL_BDIR}lib/x86_64-linux-gnu/l
 
 # create libcurl3-gnutls targets
 GNU_BDIR=curl/debian/libcurl3-gnutls/usr/
-qmstrctl create file:${GNU_BDIR}share/lintian/overrides/libcurl3-gnutls
+qmstrctl create file:${GNU_BDIR}share/lintian/overrides/libcurl3-gnutls --name libcurl3-gnutls
 
 GNU_DOC=${GNU_BDIR}share/doc/libcurl3-gnutls/
-qmstrctl create file:${GNU_DOC}NEWS.Debian.gz
-qmstrctl create file:${GNU_DOC}changelog.Debian.gz
-qmstrctl create file:${GNU_DOC}changelog.gz
-qmstrctl create file:${GNU_DOC}copyright
+qmstrctl create file:${GNU_DOC}NEWS.Debian.gz --name NEWS.Debian.gz
+qmstrctl create file:${GNU_DOC}changelog.Debian.gz --name changelog.Debian.gz
+qmstrctl create file:${GNU_DOC}changelog.gz --name changelog.gz
+qmstrctl create file:${GNU_DOC}copyright --name copyright
 
 # connect targets to libcurl3-gnutls package
 qmstrctl connect package:libcurl3-gnutls_7.64.0-3_amd64.deb \
@@ -80,13 +80,13 @@ qmstrctl connect file:hash:$(getOldestHash ${GNU_BDIR}lib/x86_64-linux-gnu/libcu
 
 # create libcurl3-nss targets
 NSS_DIR=curl/debian/libcurl3-nss/usr/
-qmstrctl create file:${NSS_DIR}share/lintian/overrides/libcurl3-nss
+qmstrctl create file:${NSS_DIR}share/lintian/overrides/libcurl3-nss --name libcurl3-nss
 
 NSS_DOC=${NSS_DIR}share/doc/libcurl3-nss/
-qmstrctl create file:${NSS_DOC}NEWS.Debian.gz
-qmstrctl create file:${NSS_DOC}changelog.Debian.gz
-qmstrctl create file:${NSS_DOC}changelog.gz
-qmstrctl create file:${NSS_DOC}copyright
+qmstrctl create file:${NSS_DOC}NEWS.Debian.gz --name NEWS.Debian.gz
+qmstrctl create file:${NSS_DOC}changelog.Debian.gz --name changelog.Debian.gz
+qmstrctl create file:${NSS_DOC}changelog.gz --name changelog.gz
+qmstrctl create file:${NSS_DOC}copyright --name copyright
 
 # connect targets to libcurl3-nss package
 qmstrctl connect package:libcurl3-nss_7.64.0-3_amd64.deb \
@@ -103,30 +103,30 @@ qmstrctl connect file:hash:$(getOldestHash ${NSS_DIR}lib/x86_64-linux-gnu/libcur
 
 # create libcurl4-openssl-dev targets
 OPENSSL_BDIR=curl/debian/libcurl4-openssl-dev/usr/
-qmstrctl create file:${OPENSSL_BDIR}bin/curl-config
+qmstrctl create file:${OPENSSL_BDIR}bin/curl-config --name curl-config
 
 H_FILES=${OPENSSL_BDIR}include/x86_64-linux-gnu/curl/
-qmstrctl create file:${H_FILES}curl.h
-qmstrctl create file:${H_FILES}curlver.h
-qmstrctl create file:${H_FILES}easy.h
-qmstrctl create file:${H_FILES}mprintf.h
-qmstrctl create file:${H_FILES}multi.h
-qmstrctl create file:${H_FILES}stdcheaders.h
-qmstrctl create file:${H_FILES}system.h
-qmstrctl create file:${H_FILES}typecheck-gcc.h
-qmstrctl create file:${H_FILES}urlapi.h
+qmstrctl create file:${H_FILES}curl.h --name curl.h
+qmstrctl create file:${H_FILES}curlver.h --name curlver.h
+qmstrctl create file:${H_FILES}easy.h --name easy.h
+qmstrctl create file:${H_FILES}mprintf.h --name mprintf.h
+qmstrctl create file:${H_FILES}multi.h --name multi.h
+qmstrctl create file:${H_FILES}stdcheaders.h --name stdcheaders.h
+qmstrctl create file:${H_FILES}system.h --name system.h
+qmstrctl create file:${H_FILES}typecheck-gcc.h --name typecheck-gcc.h
+qmstrctl create file:${H_FILES}urlapi.h --name urlapi.h
 
-qmstrctl create file:${OPENSSL_BDIR}lib/x86_64-linux-gnu/libcurl.la
-qmstrctl create file:${OPENSSL_BDIR}lib/x86_64-linux-gnu/pkgconfig/libcurl.pc
+qmstrctl create file:${OPENSSL_BDIR}lib/x86_64-linux-gnu/libcurl.la --name libcurl.la
+qmstrctl create file:${OPENSSL_BDIR}lib/x86_64-linux-gnu/pkgconfig/libcurl.pc --name libcurl.pc
 
-qmstrctl create file:${OPENSSL_BDIR}share/aclocal/libcurl.m4
-qmstrctl create file:${OPENSSL_BDIR}share/man/man1/curl-config.1.gz
+qmstrctl create file:${OPENSSL_BDIR}share/aclocal/libcurl.m4 --name libcurl.m4
+qmstrctl create file:${OPENSSL_BDIR}share/man/man1/curl-config.1.gz --name curl-config.1.gz
 
 OPENSSL_DOC=${OPENSSL_BDIR}share/doc/libcurl4-openssl-dev/
-qmstrctl create file:${OPENSSL_DOC}NEWS.Debian.gz
-qmstrctl create file:${OPENSSL_DOC}changelog.Debian.gz
-qmstrctl create file:${OPENSSL_DOC}changelog.gz
-qmstrctl create file:${OPENSSL_DOC}copyright
+qmstrctl create file:${OPENSSL_DOC}NEWS.Debian.gz --name NEWS.Debian.gz
+qmstrctl create file:${OPENSSL_DOC}changelog.Debian.gz --name changelog.Debian.gz
+qmstrctl create file:${OPENSSL_DOC}changelog.gz --name changelog.gz
+qmstrctl create file:${OPENSSL_DOC}copyright --name copyright
 
 
 # connect targets to libcurl4-openssl-dev package
@@ -157,30 +157,30 @@ qmstrctl connect package:libcurl4-openssl-dev_7.64.0-3_amd64.deb \
 
 # create libcurl4-gnutls-dev targets
 GNUTLS_DEV_BDIR=curl/debian/libcurl4-gnutls-dev/usr/
-qmstrctl create file:${GNUTLS_DEV_BDIR}bin/curl-config
+qmstrctl create file:${GNUTLS_DEV_BDIR}bin/curl-config --name curl-config
 
 H_FILES=${GNUTLS_DEV_BDIR}include/x86_64-linux-gnu/curl/
-qmstrctl create file:${H_FILES}curl.h
-qmstrctl create file:${H_FILES}curlver.h
-qmstrctl create file:${H_FILES}easy.h
-qmstrctl create file:${H_FILES}mprintf.h
-qmstrctl create file:${H_FILES}multi.h
-qmstrctl create file:${H_FILES}stdcheaders.h
-qmstrctl create file:${H_FILES}system.h
-qmstrctl create file:${H_FILES}typecheck-gcc.h
-qmstrctl create file:${H_FILES}urlapi.h
+qmstrctl create file:${H_FILES}curl.h --name curl.h
+qmstrctl create file:${H_FILES}curlver.h --name curlver.h
+qmstrctl create file:${H_FILES}easy.h --name easy.h
+qmstrctl create file:${H_FILES}mprintf.h --name mprintf.h
+qmstrctl create file:${H_FILES}multi.h --name multi.h
+qmstrctl create file:${H_FILES}stdcheaders.h --name stdcheaders.h
+qmstrctl create file:${H_FILES}system.h --name system.h
+qmstrctl create file:${H_FILES}typecheck-gcc.h --name typecheck-gcc.h
+qmstrctl create file:${H_FILES}urlapi.h --name urlapi.h
 
-qmstrctl create file:${GNUTLS_DEV_BDIR}lib/x86_64-linux-gnu/libcurl-gnutls.la
-qmstrctl create file:${GNUTLS_DEV_BDIR}lib/x86_64-linux-gnu/pkgconfig/libcurl.pc
+qmstrctl create file:${GNUTLS_DEV_BDIR}lib/x86_64-linux-gnu/libcurl-gnutls.la --name libcurl-gnutls.la
+qmstrctl create file:${GNUTLS_DEV_BDIR}lib/x86_64-linux-gnu/pkgconfig/libcurl.pc --name libcurl.pc
 
-qmstrctl create file:${GNUTLS_DEV_BDIR}share/aclocal/libcurl.m4
-qmstrctl create file:${GNUTLS_DEV_BDIR}share/man/man1/curl-config.1.gz
+qmstrctl create file:${GNUTLS_DEV_BDIR}share/aclocal/libcurl.m4 --name libcurl.m4
+qmstrctl create file:${GNUTLS_DEV_BDIR}share/man/man1/curl-config.1.gz --name curl-config.1.gz
 
 GNUTLS_DOC=${GNUTLS_DEV_BDIR}share/doc/libcurl4-gnutls-dev/
-qmstrctl create file:${GNUTLS_DOC}NEWS.Debian.gz
-qmstrctl create file:${GNUTLS_DOC}changelog.Debian.gz
-qmstrctl create file:${GNUTLS_DOC}changelog.gz
-qmstrctl create file:${GNUTLS_DOC}copyright
+qmstrctl create file:${GNUTLS_DOC}NEWS.Debian.gz --name NEWS.Debian.gz
+qmstrctl create file:${GNUTLS_DOC}changelog.Debian.gz --name changelog.Debian.gz
+qmstrctl create file:${GNUTLS_DOC}changelog.gz --name changelog.gz
+qmstrctl create file:${GNUTLS_DOC}copyright --name copyright
 
 # connect targets to libcurl3-nss package
 qmstrctl connect package:libcurl4-gnutls-dev_7.64.0-3_amd64.deb \
@@ -210,31 +210,31 @@ qmstrctl connect package:libcurl4-gnutls-dev_7.64.0-3_amd64.deb \
 
 # create libcurl4-nss-dev targets
 NSS_DEV_DIR=curl/debian/libcurl4-nss-dev/usr/
-qmstrctl create file:${NSS_DEV_DIR}bin/curl-config
+qmstrctl create file:${NSS_DEV_DIR}bin/curl-config --name curl-config
 
 H_FILES=${NSS_DEV_DIR}include/x86_64-linux-gnu/curl/
-qmstrctl create file:${H_FILES}curl.h
-qmstrctl create file:${H_FILES}curlver.h
-qmstrctl create file:${H_FILES}easy.h
-qmstrctl create file:${H_FILES}mprintf.h
-qmstrctl create file:${H_FILES}multi.h
-qmstrctl create file:${H_FILES}stdcheaders.h
-qmstrctl create file:${H_FILES}system.h
-qmstrctl create file:${H_FILES}typecheck-gcc.h
-qmstrctl create file:${H_FILES}urlapi.h
+qmstrctl create file:${H_FILES}curl.h --name curl.h
+qmstrctl create file:${H_FILES}curlver.h --name curlver.h
+qmstrctl create file:${H_FILES}easy.h --name easy.h
+qmstrctl create file:${H_FILES}mprintf.h --name mprintf.h
+qmstrctl create file:${H_FILES}multi.h --name multi.h
+qmstrctl create file:${H_FILES}stdcheaders.h --name stdcheaders.h
+qmstrctl create file:${H_FILES}system.h --name system.h
+qmstrctl create file:${H_FILES}typecheck-gcc.h --name typecheck-gcc.h
+qmstrctl create file:${H_FILES}urlapi.h --name urlapi.h
 
 LIB_NSS_DEV=${NSS_DEV_DIR}lib/x86_64-linux-gnu/
-qmstrctl create file:${LIB_NSS_DEV}libcurl-nss.la
-qmstrctl create file:${LIB_NSS_DEV}pkgconfig/libcurl.pc
+qmstrctl create file:${LIB_NSS_DEV}libcurl-nss.la --name libcurl-nss.la
+qmstrctl create file:${LIB_NSS_DEV}pkgconfig/libcurl.pc --name libcurl.pc
 
-qmstrctl create file:${NSS_DEV_DIR}share/aclocal/libcurl.m4
-qmstrctl create file:${NSS_DEV_DIR}share/man/man1/curl-config.1.gz
+qmstrctl create file:${NSS_DEV_DIR}share/aclocal/libcurl.m4 --name libcurl.m4
+qmstrctl create file:${NSS_DEV_DIR}share/man/man1/curl-config.1.gz --name curl-config.1.gz
 
 NSS_DEV_DOC=${NSS_DEV_DIR}share/doc/libcurl4-nss-dev/
-qmstrctl create file:${NSS_DEV_DOC}NEWS.Debian.gz
-qmstrctl create file:${NSS_DEV_DOC}changelog.Debian.gz
-qmstrctl create file:${NSS_DEV_DOC}changelog.gz
-qmstrctl create file:${NSS_DEV_DOC}copyright
+qmstrctl create file:${NSS_DEV_DOC}NEWS.Debian.gz --name NEWS.Debian.gz
+qmstrctl create file:${NSS_DEV_DOC}changelog.Debian.gz --name changelog.Debian.gz
+qmstrctl create file:${NSS_DEV_DOC}changelog.gz --name changelog.gz
+qmstrctl create file:${NSS_DEV_DOC}copyright --name copyright
 
 
 # connect targets to libcurl4-nss-dev package

--- a/demos/debian-curl/targets.sh
+++ b/demos/debian-curl/targets.sh
@@ -5,6 +5,14 @@ function hashthis() {
   sha1sum $1 | awk '{ print $1 }'
 }
 
+# getOldestHash() uses the path and the timestamp of a node
+# and returns the hash of the oldest node
+function getOldestHash() {
+	TIMESTAMP=`qmstrctl describe file:path:$1 | grep $1 | awk '/Timestamp/{print $NF}' | sort -n | head -1`
+    TIMESTAMP="/${TIMESTAMP}/"
+	qmstrctl describe file:path:$1 | grep $1 | awk -F'[ ,]' '$TIMESTAMP{print $9}' | head -1
+}
+
 # create curl targets
 CURL_BDIR=curl/debian/curl/usr/
 qmstrctl create file:${CURL_BDIR}share/doc/curl/NEWS.Debian.gz
@@ -24,6 +32,10 @@ qmstrctl connect package:curl_7.64.0-3_amd64.deb \
 	file:${CURL_BDIR}share/man/man1/curl.1.gz \
 	file:${CURL_BDIR}share/zsh/vendor-completions/_curl
 
+# connect missing dependencies
+qmstrctl connect file:hash:$(getOldestHash ${CURL_BDIR}bin/curl) \
+	file:path:curl/debian/build/src/.libs/curl
+
 # create libcurl4 targets
 LIBCURL_BDIR=curl/debian/libcurl4/usr/
 qmstrctl create file:${LIBCURL_BDIR}share/doc/libcurl4/NEWS.Debian.gz
@@ -38,6 +50,10 @@ qmstrctl connect package:libcurl4_7.64.0-3_amd64.deb \
 	file:${LIBCURL_BDIR}share/doc/libcurl4/changelog.Debian.gz \
 	file:${LIBCURL_BDIR}share/doc/libcurl4/changelog.gz \
 	file:${LIBCURL_BDIR}share/doc/libcurl4/copyright
+
+# connect missing dependencies
+qmstrctl connect file:hash:$(getOldestHash ${LIBCURL_BDIR}lib/x86_64-linux-gnu/libcurl.so.4.5.0) \
+    file:path:curl/debian/build/lib/.libs/libcurl.so
 
 # create libcurl3-gnutls targets
 GNU_BDIR=curl/debian/libcurl3-gnutls/usr/
@@ -58,6 +74,10 @@ qmstrctl connect package:libcurl3-gnutls_7.64.0-3_amd64.deb \
 	file:${GNU_DOC}copyright \
 	file:${GNU_BDIR}share/lintian/overrides/libcurl3-gnutls
 
+# connect missing dependencies
+qmstrctl connect file:hash:$(getOldestHash ${GNU_BDIR}lib/x86_64-linux-gnu/libcurl-gnutls.so.4.5.0) \
+    file:path:curl/debian/build-gnutls/lib/.libs/libcurl-gnutls.so
+
 # create libcurl3-nss targets
 NSS_DIR=curl/debian/libcurl3-nss/usr/
 qmstrctl create file:${NSS_DIR}share/lintian/overrides/libcurl3-nss
@@ -76,6 +96,10 @@ qmstrctl connect package:libcurl3-nss_7.64.0-3_amd64.deb \
 	file:${NSS_DOC}changelog.gz \
 	file:${NSS_DOC}copyright \
 	file:${NSS_DIR}share/lintian/overrides/libcurl3-nss
+
+# connect missing dependencies
+qmstrctl connect file:hash:$(getOldestHash ${NSS_DIR}lib/x86_64-linux-gnu/libcurl-nss.so.4.5.0) \
+    file:path:curl/debian/build-nss/lib/.libs/libcurl-nss.so
 
 # create libcurl4-openssl-dev targets
 OPENSSL_BDIR=curl/debian/libcurl4-openssl-dev/usr/


### PR DESCRIPTION
closes https://github.com/QMSTR/qmstr/issues/358

In Debian curl build, while the binaries are copied and installed into the Debian packages we miss the information that between these stages the binaries are changed. 
In this PR, we connect the unmodified and the modified nodes (all nodes are already in the database- we just miss the connections) to include all the information into the database. 